### PR TITLE
Ordinals Support

### DIFF
--- a/addons/godot-stacks-sdk/StacksGlobals.gd
+++ b/addons/godot-stacks-sdk/StacksGlobals.gd
@@ -4,6 +4,7 @@ enum WalletType { NONE, STACKS }
 var current_wallet_type = WalletType.NONE
 
 var wallet : String = ""
+var btc_addresses : Array = []
 
 const USER_DATA_SAVE_PATH = "user://user_data.cfg"
 const DATA_SECTION = "StacksData" # Name of the section in the user data file that contains the user's info.
@@ -14,6 +15,9 @@ func set_wallet_type(wallet_type: int) -> void:
 func clear_wallet() -> void:
 	wallet = ""
 	current_wallet_type = WalletType.NONE
+
+func clear_bitcoin_addresses() -> void:
+	btc_addresses.clear()
 
 func is_valid_wallet_type(wallet_type: int) -> bool:
 	return wallet_type in [WalletType.STACKS]

--- a/addons/godot-stacks-sdk/plugin.cfg
+++ b/addons/godot-stacks-sdk/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot Stacks SDK"
 description="A simple SDK to integrate Stacks into Godot."
 author="svntax"
-version="1.0"
+version="1.1"
 script="plugin.gd"

--- a/addons/godot-stacks-sdk/tests/LoginManager.gd
+++ b/addons/godot-stacks-sdk/tests/LoginManager.gd
@@ -20,6 +20,8 @@ func _ready():
 	else:
 		var account = user_config.get_value(StacksGlobals.DATA_SECTION, "StacksAccount", "")
 		var wallet_type = user_config.get_value(StacksGlobals.DATA_SECTION, "StacksWalletType", -1)
+		var btc_addresses = user_config.get_value(StacksGlobals.DATA_SECTION, "BitcoinAddresses", [])
+		StacksGlobals.btc_addresses = btc_addresses
 		if account != null and account != "" and wallet_type != null and StacksGlobals.is_valid_wallet_type(wallet_type):
 			# Wallet account detected, skip the login screen
 			StacksGlobals.wallet = account
@@ -56,6 +58,7 @@ func save_user_login() -> void:
 		user_config = ConfigFile.new()
 	user_config.set_value(StacksGlobals.DATA_SECTION, "StacksAccount", StacksGlobals.wallet)
 	user_config.set_value(StacksGlobals.DATA_SECTION, "StacksWalletType", StacksGlobals.current_wallet_type)
+	user_config.set_value(StacksGlobals.DATA_SECTION, "BitcoinAddresses", StacksGlobals.btc_addresses)
 	user_config.save(StacksGlobals.USER_DATA_SAVE_PATH)
 
 func show_loading_ui() -> void:

--- a/addons/godot-stacks-sdk/tests/MainSceneManager.gd
+++ b/addons/godot-stacks-sdk/tests/MainSceneManager.gd
@@ -2,8 +2,6 @@ extends Node2D
 
 const NftInfoCard = preload("res://addons/godot-stacks-sdk/tests/NftInfo.tscn")
 
-onready var wallet_connector = $WalletConnector
-
 onready var wallet_label = $UI/WalletLabel
 onready var check_user_nfts_button = $UI/CheckUserNFTsButton
 onready var nft_list_container = $UI/NftList/HBoxContainer

--- a/addons/godot-stacks-sdk/tests/MainSceneManager.gd
+++ b/addons/godot-stacks-sdk/tests/MainSceneManager.gd
@@ -17,7 +17,7 @@ func _ready():
 	nft_error_label.hide()
 	# Get and display the wallet addresses
 	wallet_label.text = "Wallet: " + StacksGlobals.wallet
-	btc_addresses_label.text = "BTC Addresses: "
+	btc_addresses_label.text = "BTC Addresses:\n"
 	for address in StacksGlobals.btc_addresses:
 		btc_addresses_label.text += address + "\n"
 

--- a/addons/godot-stacks-sdk/tests/TestMainScene.tscn
+++ b/addons/godot-stacks-sdk/tests/TestMainScene.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://addons/godot-stacks-sdk/utils/WalletConnector.gd" type="Script" id=2]
 [ext_resource path="res://addons/godot-stacks-sdk/tests/MainSceneManager.gd" type="Script" id=3]
 
 [node name="TestMainScene" type="Node2D"]
@@ -8,9 +7,6 @@ script = ExtResource( 3 )
 __meta__ = {
 "_edit_lock_": true
 }
-
-[node name="WalletConnector" type="Node" parent="."]
-script = ExtResource( 2 )
 
 [node name="UI" type="CanvasLayer" parent="."]
 

--- a/addons/godot-stacks-sdk/tests/TestMainScene.tscn
+++ b/addons/godot-stacks-sdk/tests/TestMainScene.tscn
@@ -22,7 +22,8 @@ margin_left = 64.0
 margin_top = 104.0
 margin_right = 250.0
 margin_bottom = 118.0
-text = "BTC Wallets: bc1234567890"
+text = "BTC Wallets:
+bc1234567890"
 
 [node name="CheckUserNFTsButton" type="Button" parent="UI"]
 anchor_left = 0.5
@@ -145,22 +146,16 @@ margin_top = 32.0
 margin_right = 1212.0
 margin_bottom = 488.0
 
-[node name="ScrollContainer" type="ScrollContainer" parent="UI/TabContainer/Ordinals/Panel"]
-margin_right = 1152.0
-margin_bottom = 456.0
-scroll_horizontal_enabled = false
-
-[node name="VBoxContainer" type="VBoxContainer" parent="UI/TabContainer/Ordinals/Panel/ScrollContainer"]
-margin_right = 1152.0
-margin_bottom = 14.0
-size_flags_horizontal = 3
-
-[node name="InscriptionsLabel" type="Label" parent="UI/TabContainer/Ordinals/Panel/ScrollContainer/VBoxContainer"]
+[node name="InscriptionsLabel" type="TextEdit" parent="UI/TabContainer/Ordinals/Panel"]
 unique_name_in_owner = true
 margin_right = 1152.0
-margin_bottom = 14.0
+margin_bottom = 456.0
+rect_min_size = Vector2( 0, 16 )
+custom_colors/font_color_readonly = Color( 1, 1, 1, 1 )
 text = "No content"
-autowrap = true
+readonly = true
+middle_mouse_paste_enabled = false
+wrap_enabled = true
 
 [connection signal="pressed" from="UI/CheckUserNFTsButton" to="." method="_on_CheckUserNFTsButton_pressed"]
 [connection signal="pressed" from="UI/CheckUserOrdinalsButton" to="." method="_on_CheckUserOrdinalsButton_pressed"]

--- a/addons/godot-stacks-sdk/tests/TestMainScene.tscn
+++ b/addons/godot-stacks-sdk/tests/TestMainScene.tscn
@@ -12,90 +12,156 @@ __meta__ = {
 
 [node name="WalletLabel" type="Label" parent="UI"]
 margin_left = 64.0
-margin_top = 64.0
-margin_right = 201.0
-margin_bottom = 78.0
+margin_top = 80.0
+margin_right = 250.0
+margin_bottom = 94.0
 text = "Wallet: SP1234567890abcdef"
+
+[node name="BtcAddressesLabel" type="Label" parent="UI"]
+margin_left = 64.0
+margin_top = 104.0
+margin_right = 250.0
+margin_bottom = 118.0
+text = "BTC Wallets: bc1234567890"
 
 [node name="CheckUserNFTsButton" type="Button" parent="UI"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -96.0
-margin_top = -293.0
-margin_right = 96.0
-margin_bottom = -229.0
-rect_min_size = Vector2( 192, 64 )
-text = "Check user's NFTs"
+margin_left = 320.0
+margin_top = -312.0
+margin_right = 512.0
+margin_bottom = -264.0
+rect_min_size = Vector2( 192, 48 )
+text = "Check Stacks NFTs"
+
+[node name="CheckUserOrdinalsButton" type="Button" parent="UI"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = 320.0
+margin_top = -248.0
+margin_right = 512.0
+margin_bottom = -200.0
+rect_min_size = Vector2( 192, 48 )
+text = "Check Ordinals"
 
 [node name="TokenAddress" type="LineEdit" parent="UI"]
+unique_name_in_owner = true
 margin_left = 531.0
-margin_top = 14.0
+margin_top = 24.0
 margin_right = 917.0
-margin_bottom = 38.0
+margin_bottom = 48.0
 text = "SP2W12MNM4SPV37VZHN4GCDG35G9ACG3FDKK7WF04"
 
 [node name="TokenAddressLabel" type="Label" parent="UI"]
+unique_name_in_owner = true
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 margin_left = -333.0
-margin_top = -346.0
+margin_top = -336.0
 margin_right = -121.0
-margin_bottom = -322.0
-text = "Contract Address to check"
+margin_bottom = -312.0
+text = "STX Contract Address to check"
 align = 2
 valign = 1
 
-[node name="NftListLabel" type="Label" parent="UI"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -576.0
-margin_top = -200.0
-margin_right = -545.0
-margin_bottom = -176.0
-text = "NFT Collection:"
+[node name="LogoutButton" type="Button" parent="UI"]
+margin_left = 1176.0
+margin_top = 16.0
+margin_right = 1256.0
+margin_bottom = 56.0
+text = "Logout"
 
-[node name="ListBg" type="ColorRect" parent="UI"]
-margin_left = 48.0
-margin_top = 184.0
-margin_right = 1232.0
-margin_bottom = 702.0
+[node name="TabContainer" type="TabContainer" parent="UI"]
+margin_top = 152.0
+margin_right = 1280.0
+margin_bottom = 720.0
+
+[node name="Stacks" type="Tabs" parent="UI/TabContainer"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+
+[node name="ListBg" type="ColorRect" parent="UI/TabContainer/Stacks"]
+margin_left = 44.0
+margin_top = 456.0
+margin_right = 1228.0
+margin_bottom = 518.0
 color = Color( 0.152941, 0.152941, 0.160784, 1 )
 
-[node name="NftErrorLabel" type="Label" parent="UI"]
+[node name="NftErrorLabel" type="Label" parent="UI/TabContainer/Stacks"]
 unique_name_in_owner = true
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
 margin_left = -568.0
-margin_top = -504.0
+margin_top = -500.0
 margin_right = -352.0
-margin_bottom = -480.0
+margin_bottom = -476.0
 text = "Failed to get NFTs"
 autowrap = true
 
-[node name="NftList" type="ScrollContainer" parent="UI"]
-margin_left = 64.0
-margin_top = 200.0
-margin_right = 1216.0
-margin_bottom = 606.0
+[node name="NftList" type="ScrollContainer" parent="UI/TabContainer/Stacks"]
+margin_left = 60.0
+margin_top = 16.0
+margin_right = 1212.0
+margin_bottom = 422.0
 scroll_vertical_enabled = false
 
-[node name="HBoxContainer" type="HBoxContainer" parent="UI/NftList"]
+[node name="NftListBoxContainer" type="HBoxContainer" parent="UI/TabContainer/Stacks/NftList"]
+unique_name_in_owner = true
 custom_constants/separation = 32
 
-[node name="LogoutButton" type="Button" parent="UI"]
-margin_left = 1112.0
-margin_top = 34.0
-margin_right = 1192.0
-margin_bottom = 74.0
-text = "Logout"
+[node name="NftListLabel" type="Label" parent="UI/TabContainer/Stacks"]
+unique_name_in_owner = true
+margin_left = 68.0
+margin_top = 456.0
+margin_right = 164.0
+margin_bottom = 518.0
+text = "NFT Collection:"
+valign = 1
+
+[node name="Ordinals" type="Tabs" parent="UI/TabContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+
+[node name="Panel" type="Panel" parent="UI/TabContainer/Ordinals"]
+margin_left = 60.0
+margin_top = 32.0
+margin_right = 1212.0
+margin_bottom = 488.0
+
+[node name="ScrollContainer" type="ScrollContainer" parent="UI/TabContainer/Ordinals/Panel"]
+margin_right = 1152.0
+margin_bottom = 456.0
+scroll_horizontal_enabled = false
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI/TabContainer/Ordinals/Panel/ScrollContainer"]
+margin_right = 1152.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+
+[node name="InscriptionsLabel" type="Label" parent="UI/TabContainer/Ordinals/Panel/ScrollContainer/VBoxContainer"]
+unique_name_in_owner = true
+margin_right = 1152.0
+margin_bottom = 14.0
+text = "No content"
+autowrap = true
 
 [connection signal="pressed" from="UI/CheckUserNFTsButton" to="." method="_on_CheckUserNFTsButton_pressed"]
+[connection signal="pressed" from="UI/CheckUserOrdinalsButton" to="." method="_on_CheckUserOrdinalsButton_pressed"]
 [connection signal="pressed" from="UI/LogoutButton" to="." method="_on_LogoutButton_pressed"]

--- a/addons/godot-stacks-sdk/utils/WalletConnector.gd
+++ b/addons/godot-stacks-sdk/utils/WalletConnector.gd
@@ -33,10 +33,12 @@ func _on_wallet_connected(res):
 		var parsed_json = JSON.parse(json_string)
 		if parsed_json.error == OK:
 			var addresses = parsed_json.result
-			# Search for the STX address
+			# Search for the STX and BTC addresses
 			for address_obj in addresses:
 				var symbol = address_obj.symbol
 				if symbol == "STX":
 					StacksGlobals.wallet = address_obj.address
+				elif symbol == "BTC":
+					StacksGlobals.btc_addresses.append(address_obj.address)
 	
 	emit_signal("wallet_connected", StacksGlobals.wallet)


### PR DESCRIPTION
Added support for reading ordinals through Hiro's Ordinals API (https://docs.hiro.so/ordinals)

Not all endpoints and parameters are included, but at a minimum, `getInscriptions` can be used with parameters for the addresses, limit, and offset.

The test scene has been updated with a new section to test reading the user's ordinals.